### PR TITLE
form builder group was too lenient

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -13,7 +13,7 @@ export type StateAndValidators<T> = [FormState<T>] |
   [FormState<T>, ValidatorFn<T> | ValidatorFn<T>[] | null, AsyncValidatorFn<T> | AsyncValidatorFn<T>[] | null]
 
 export type ControlConfig<T> = FormState<T> | StateAndValidators<T> | AbstractControl<T>;
-export type ControlsConfig<T> = ControlConfig<T> | { [P in keyof T]: ControlConfig<T[P]> };
+export type ControlsConfig<T> = { [P in keyof T]: ControlConfig<T[P]> };
 
 export interface AbstractControlOptions<T> {
   validators?: ValidatorFn<T> | ValidatorFn<T>[] | null;

--- a/test/compile-test-form-builder.ts
+++ b/test/compile-test-form-builder.ts
@@ -32,8 +32,13 @@ const namecontrol: AbstractControl<string> | null = heroFormGroup.get('name');
 const lairs: AbstractControl<Address[]> | null = heroFormGroup.get('secretLairs');
 
 let barFormGroup: FormGroup<Bar>;
-barFormGroup= fb.group<Bar>([{prop: ''}]);
-barFormGroup = fb.group<Bar>([{value: {prop: ''}, disabled: true}]);
-barFormGroup = fb.group<Bar>([{prop: ''}, Validators.required]);
-barFormGroup = fb.group<Bar>([{prop: ''}, [Validators.required, Validators.minLength(5)]]);
+barFormGroup= fb.group<Bar>({prop: ''});
+barFormGroup = fb.group<Bar>({prop: {value: '', disabled: true}});
+barFormGroup = fb.group<Bar>({prop: ['', Validators.required]});
+barFormGroup = fb.group<Bar>({prop: ['', [Validators.required, Validators.minLength(5)]]});
 
+let barFormControl: FormControl<Bar>;
+barFormControl= fb.control<Bar>({prop: ''});
+barFormControl = fb.control<Bar>({value: {prop: ''}, disabled: true});
+barFormControl = fb.control<Bar>({prop: ''}, Validators.required);
+barFormControl = fb.control<Bar>({prop: ''}, [Validators.required, Validators.minLength(5)]);


### PR DESCRIPTION
```
fb.group<Bar>(
  [
    {prop: ''}
  ]
)
```
would have created a group with a control called "0", ie., rather than match `Bar` it matches the model: `{ "0": Bar }`