### PR TITLE
Feature/infer controls

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,6 +9,9 @@ var gulp = require('gulp'),
   bump = require('gulp-bump');
 const version = require('./package').version;
 
+// for the side effect of configuring ngc
+require('@angular/compiler-cli');
+
 const rootFolder = path.join(__dirname);
 const srcFolder = path.join(rootFolder, 'src');
 const tmpFolder = path.join(rootFolder, '.tmp');

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,27 +5,27 @@
   "requires": true,
   "dependencies": {
     "@angular/common": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-8.0.2.tgz",
-      "integrity": "sha512-9lwrKso0XjyS7wu+8dEWa5yN1kCTdbelP6JElFhh0kAt0TbPVHJ/dXEwvIFk9/2MjYv2PbooQo1zsc5kAB2Rlg==",
+      "version": "8.2.14",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-8.2.14.tgz",
+      "integrity": "sha512-Qmt+aX2quUW54kaNT7QH7WGXnFxr/cC2C6sf5SW5SdkZfDQSiz8IaItvieZfXVQUbBOQKFRJ7TlSkt0jI/yjvw==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
       }
     },
     "@angular/compiler": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-8.0.2.tgz",
-      "integrity": "sha512-ktobrxpWX1eCwbDKOIUm5GRj8WGlHW/8MAQvDDFUnsGqXBHfOGiaySiEYX/XjeN8qu34IfXs736QkdzpMM4+iw==",
+      "version": "8.2.14",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-8.2.14.tgz",
+      "integrity": "sha512-ABZO4E7eeFA1QyJ2trDezxeQM5ZFa1dXw1Mpl/+1vuXDKNjJgNyWYwKp/NwRkLmrsuV0yv4UDCDe4kJOGbPKnw==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
       }
     },
     "@angular/compiler-cli": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-8.0.2.tgz",
-      "integrity": "sha512-9jdpB8WC47oSgQ/jA+ExTYqbe4xw3ZCEhgLhPd8BQukBOHodaIHKnkinrVJAPZORpY1CKRaImoAHieSvRhiPjA==",
+      "version": "8.2.14",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-8.2.14.tgz",
+      "integrity": "sha512-XDrTyrlIZM+0NquVT+Kbg5bn48AaWFT+B3bAT288PENrTdkuxuF9AhjFRZj8jnMdmaE4O2rioEkXBtl6z3zptA==",
       "dev": true,
       "requires": {
         "canonical-path": "1.0.0",
@@ -35,34 +35,33 @@
         "magic-string": "^0.25.0",
         "minimist": "^1.2.0",
         "reflect-metadata": "^0.1.2",
-        "shelljs": "^0.8.1",
         "source-map": "^0.6.1",
         "tslib": "^1.9.0",
         "yargs": "13.1.0"
       }
     },
     "@angular/core": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-8.0.2.tgz",
-      "integrity": "sha512-g8BRvGZxTXb5GZ/xoC5Z94DGK3wMiD2jbmEQEbXGNM+c8E/Mo/W8GF44P7EU2d+V1oJoUh75SRK6U/StC+rLqA==",
+      "version": "8.2.14",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-8.2.14.tgz",
+      "integrity": "sha512-zeePkigi+hPh3rN7yoNENG/YUBUsIvUXdxx+AZq+QPaFeKEA2FBSrKn36ojHFrdJUjKzl0lPMEiGC2b6a6bo6g==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
       }
     },
     "@angular/forms": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-8.0.2.tgz",
-      "integrity": "sha512-LGu3b/wjNMCki5PnMUsfQlyaVZVOedNO+XccfluP4ZBQ5G/E2cz2tJ0UIHg3RhLbbpWntmqokpYLyd7leUPpIQ==",
+      "version": "8.2.14",
+      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-8.2.14.tgz",
+      "integrity": "sha512-zhyKL3CFIqcyHJ/TQF/h1OZztK611a6rxuPHCrt/5Sn1SuBTJJQ1pPTkOYIDy6IrCrtyANc8qB6P17Mao71DNQ==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
       }
     },
     "@angular/platform-browser": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-8.0.2.tgz",
-      "integrity": "sha512-iUoyhJ81jqvpmQI6Lu5NzRZR8azmnb2kX2FQ+LbwCvWQLfkLbTaa/Jl09/qN6KWpTsMogNQXVnjjgwoeaObvBw==",
+      "version": "8.2.14",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-8.2.14.tgz",
+      "integrity": "sha512-MtJptptyKzsE37JZ2VB/tI4cvMrdAH+cT9pMBYZd66YSZfKjIj5s+AZo7z8ncoskQSB1o3HMfDjSK7QXGx1mLQ==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -306,6 +305,16 @@
       "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
       "dev": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -430,9 +439,9 @@
       }
     },
     "chokidar": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.6.tgz",
-      "integrity": "sha512-V2jUo67OKkc6ySiRpJrjlpJKl9kDuG+Xb8VgsGzb+aEouhgS1D0weyPU4lEzdAcsCAvrih2J2BqyXqHWvVLw5g==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
+      "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
       "dev": true,
       "requires": {
         "anymatch": "^2.0.0",
@@ -580,9 +589,9 @@
       "dev": true
     },
     "convert-source-map": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
-      "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+      "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
       "dev": true,
       "requires": {
         "safe-buffer": "~5.1.1"
@@ -614,9 +623,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
         }
       }
@@ -969,6 +978,13 @@
         "color-support": "^1.1.3",
         "time-stamp": "^1.0.0"
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
     },
     "fill-range": {
       "version": "4.0.0",
@@ -1363,21 +1379,16 @@
         "universalify": "^0.1.0"
       }
     },
-    "fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
-    },
     "fsevents": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
-      "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.11.tgz",
+      "integrity": "sha512-+ux3lx6peh0BpvY0JebGyZoiR4D+oYzdPZMKJwkZ+sFkNJzpL7tXc/wehS49gUAxg3tmMHPHZkA8JU2rhhgDHw==",
       "dev": true,
       "optional": true,
       "requires": {
+        "bindings": "^1.5.0",
         "nan": "^2.12.1",
-        "node-pre-gyp": "^0.12.0"
+        "node-pre-gyp": "*"
       },
       "dependencies": {
         "abbrev": {
@@ -1425,7 +1436,7 @@
           }
         },
         "chownr": {
-          "version": "1.1.1",
+          "version": "1.1.3",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -1455,7 +1466,7 @@
           "optional": true
         },
         "debug": {
-          "version": "4.1.1",
+          "version": "3.2.6",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -1482,12 +1493,12 @@
           "optional": true
         },
         "fs-minipass": {
-          "version": "1.2.5",
+          "version": "1.2.7",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "^2.6.0"
           }
         },
         "fs.realpath": {
@@ -1513,7 +1524,7 @@
           }
         },
         "glob": {
-          "version": "7.1.3",
+          "version": "7.1.6",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -1542,7 +1553,7 @@
           }
         },
         "ignore-walk": {
-          "version": "3.0.1",
+          "version": "3.0.3",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -1561,7 +1572,7 @@
           }
         },
         "inherits": {
-          "version": "2.0.3",
+          "version": "2.0.4",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -1603,7 +1614,7 @@
           "optional": true
         },
         "minipass": {
-          "version": "2.3.5",
+          "version": "2.9.0",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -1613,12 +1624,12 @@
           }
         },
         "minizlib": {
-          "version": "1.2.1",
+          "version": "1.3.3",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "^2.9.0"
           }
         },
         "mkdirp": {
@@ -1631,24 +1642,24 @@
           }
         },
         "ms": {
-          "version": "2.1.1",
+          "version": "2.1.2",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "needle": {
-          "version": "2.3.0",
+          "version": "2.4.0",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "^4.1.0",
+            "debug": "^3.2.6",
             "iconv-lite": "^0.4.4",
             "sax": "^1.2.4"
           }
         },
         "node-pre-gyp": {
-          "version": "0.12.0",
+          "version": "0.14.0",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -1662,7 +1673,7 @@
             "rc": "^1.2.7",
             "rimraf": "^2.6.1",
             "semver": "^5.3.0",
-            "tar": "^4"
+            "tar": "^4.4.2"
           }
         },
         "nopt": {
@@ -1676,13 +1687,22 @@
           }
         },
         "npm-bundled": {
-          "version": "1.0.6",
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "npm-normalize-package-bin": "^1.0.1"
+          }
+        },
+        "npm-normalize-package-bin": {
+          "version": "1.0.1",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
-          "version": "1.4.1",
+          "version": "1.4.7",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -1753,7 +1773,7 @@
           "optional": true
         },
         "process-nextick-args": {
-          "version": "2.0.0",
+          "version": "2.0.1",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -1794,7 +1814,7 @@
           }
         },
         "rimraf": {
-          "version": "2.6.3",
+          "version": "2.7.1",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -1821,7 +1841,7 @@
           "optional": true
         },
         "semver": {
-          "version": "5.7.0",
+          "version": "5.7.1",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -1874,18 +1894,18 @@
           "optional": true
         },
         "tar": {
-          "version": "4.4.8",
+          "version": "4.4.13",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
             "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.4",
-            "minizlib": "^1.1.1",
+            "minipass": "^2.8.6",
+            "minizlib": "^1.2.1",
             "mkdirp": "^0.5.0",
             "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.2"
+            "yallist": "^3.0.3"
           }
         },
         "util-deprecate": {
@@ -1910,7 +1930,7 @@
           "optional": true
         },
         "yallist": {
-          "version": "3.0.3",
+          "version": "3.1.1",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -2908,9 +2928,9 @@
       "dev": true
     },
     "magic-string": {
-      "version": "0.25.2",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.2.tgz",
-      "integrity": "sha512-iLs9mPjh9IuTtRsqqhNGYcZXGei0Nh/A4xirrsqW7c+QhKVFL2vm7U09ru6cHRD22azaP/wMDgI+HCqbETMTtg==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.5.tgz",
+      "integrity": "sha512-vIO/BOm9odBHBAGwv0gZPLJeO9IpwliiIc0uPeAW93rrFMJ/R3M665IAEfOU/IW3kD4S9AtEn76lfTn1Yif+9A==",
       "dev": true,
       "requires": {
         "sourcemap-codec": "^1.4.4"
@@ -3034,15 +3054,6 @@
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true
-    },
-    "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
-      "requires": {
-        "brace-expansion": "^1.1.7"
-      }
     },
     "minimist": {
       "version": "1.2.0",
@@ -3365,9 +3376,9 @@
       "dev": true
     },
     "p-limit": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-      "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+      "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
       "dev": true,
       "requires": {
         "p-try": "^2.0.0"
@@ -3571,9 +3582,9 @@
       },
       "dependencies": {
         "end-of-stream": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-          "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+          "version": "1.4.4",
+          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+          "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
           "dev": true,
           "requires": {
             "once": "^1.4.0"
@@ -3852,33 +3863,6 @@
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
     },
-    "shelljs": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.3.tgz",
-      "integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
-      "dev": true,
-      "requires": {
-        "glob": "^7.0.0",
-        "interpret": "^1.0.0",
-        "rechoir": "^0.6.2"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "7.1.4",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        }
-      }
-    },
     "sigmund": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
@@ -4031,9 +4015,9 @@
       "dev": true
     },
     "sourcemap-codec": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.4.tgz",
-      "integrity": "sha512-CYAPYdBu34781kLHkaW3m6b/uUSyMOC2R61gcYMWooeuaGtjof86ZA/8T+qVPPt7np1085CR9hmMGrySwEc8Xg==",
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.7.tgz",
+      "integrity": "sha512-RuN23NzhAOuUtaivhcrjXx1OPXsFeH9m5sI373/U7+tGLKihjUyboZAzOadytMjnqHp1f45RGk1IzDKCpDpSYA==",
       "dev": true
     },
     "sparkles": {
@@ -4284,9 +4268,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
-      "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
+      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
       "dev": true
     },
     "unc-path-regex": {
@@ -4389,9 +4373,9 @@
       }
     },
     "upath": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/upath/-/upath-1.1.2.tgz",
-      "integrity": "sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
+      "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
       "dev": true
     },
     "urix": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3158,10 +3158,9 @@
       }
     },
     "natives": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.4.tgz",
-      "integrity": "sha512-Q29yeg9aFKwhLVdkTAejM/HvYG0Y1Am1+HUkFQGn5k2j8GS+v60TVmZh6nujpEAj/qql+wGUrlryO8bF+b1jEg==",
-      "dev": true
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.6.tgz",
+      "integrity": "sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA=="
     },
     "nice-try": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -21,16 +21,16 @@
     "type definition"
   ],
   "peerDependencies": {
-    "@angular/forms": "^8.0.0",
-    "rxjs": "^5.x || ^6.x"
+    "@angular/forms": "^8.2.0",
+    "rxjs": "^6.4"
   },
   "devDependencies": {
-    "@angular/common": "^8.0.1",
-    "@angular/compiler": "^8.0.1",
-    "@angular/compiler-cli": "^8.0.1",
-    "@angular/core": "^8.0.1",
-    "@angular/forms": "^8.0.1",
-    "@angular/platform-browser": "^8.0.1",
+    "@angular/common": "^8.2.14",
+    "@angular/compiler": "^8.2.14",
+    "@angular/compiler-cli": "^8.2.14",
+    "@angular/core": "^8.2.14",
+    "@angular/forms": "^8.2.14",
+    "@angular/platform-browser": "^8.2.14",
     "fs-extra": "^5.0.0",
     "gulp": "^3.9.1",
     "gulp-bump": "^3.1.1",
@@ -39,7 +39,7 @@
     "rollup": "^0.49.3",
     "run-sequence": "^1.2.2",
     "rxjs": "^6.4.0",
-    "typescript": "~3.4",
+    "typescript": "3.5.3",
     "zone.js": "^0.9.1"
   },
   "repository": {

--- a/src/interop.ts
+++ b/src/interop.ts
@@ -7,8 +7,8 @@ import {
 import { AbstractControl, FormArray, FormControl, FormGroup, Controls} from './model';
 
 export function toUntyped<T>(control: FormControl<T>): NgFormControl;
-export function toUntyped<T>(control: FormGroup<Controls<any>>): NgFormGroup;
-export function toUntyped<T>(control: FormArray<AbstractControl<any>>): NgFormArray;
+export function toUntyped<T extends Controls<any>>(control: FormGroup<T>): NgFormGroup;
+export function toUntyped<T extends AbstractControl<any>>(control: FormArray<T>): NgFormArray;
 export function toUntyped<T>(control: AbstractControl<any, any>): NgAbstractControl;
 export function toUntyped<T>(control: any): any {
   return control as any;

--- a/src/interop.ts
+++ b/src/interop.ts
@@ -4,12 +4,12 @@ import {
   FormControl as NgFormControl,
   FormGroup as NgFormGroup
 } from '@angular/forms';
-import {AbstractControl, FormArray, FormControl, FormGroup} from './model';
+import { AbstractControl, FormArray, FormControl, FormGroup, Controls} from './model';
 
 export function toUntyped<T>(control: FormControl<T>): NgFormControl;
-export function toUntyped<T>(control: FormGroup<T>): NgFormGroup;
-export function toUntyped<T>(control: FormArray<T>): NgFormArray;
-export function toUntyped<T>(control: AbstractControl<T>): NgAbstractControl;
+export function toUntyped<T>(control: FormGroup<Controls<any>>): NgFormGroup;
+export function toUntyped<T>(control: FormArray<AbstractControl<any>>): NgFormArray;
+export function toUntyped<T>(control: AbstractControl<any, any>): NgAbstractControl;
 export function toUntyped<T>(control: any): any {
   return control as any;
 }

--- a/src/model.ts
+++ b/src/model.ts
@@ -6,7 +6,7 @@ export type FormHooks = 'change' | 'blur' | 'submit';
 export type ValidatorFn<T> = NgValidatorFN | TypedValidatorFn<T>
 export type AsyncValidatorFn<T> = NgAsyncValidatorFn | TypedAsyncValidatorFn<T>
 
-export type Controls<T = unknown> = { [P in keyof T]: AbstractControl<T[P]> };
+export type Controls<T = unknown> = { [P in keyof T]: AbstractControl<T[P], any> };
 export type FormState<T> = T | { value: T, disabled: boolean };
 export type StateAndValidators<T> = [FormState<T>] |
   [FormState<T>, ValidatorFn<T> | ValidatorFn<T>[]] |

--- a/src/model.ts
+++ b/src/model.ts
@@ -1065,7 +1065,7 @@ export class FormGroup<T extends Controls<any> = Controls> extends AbstractContr
    * The configuration options are passed to the {@link AbstractControl#updateValueAndValidity
    * updateValueAndValidity} method.
    */
-  patchValue(value: Partial<Static<this>>, options?: {
+  patchValue(value: Partial<ControlsStaticType<T>>, options?: {
     onlySelf?: boolean;
     emitEvent?: boolean;
   }): void {
@@ -1128,7 +1128,7 @@ export class FormGroup<T extends Controls<any> = Controls> extends AbstractContr
    * console.log(this.form.get('first').status);  // 'DISABLED'
    * ```
    */
-  reset(value?: Partial<Static<this>>, options?: {
+  reset(value?: Partial<ControlsStaticType<T>>, options?: {
     onlySelf?: boolean;
     emitEvent?: boolean;
   }): void {

--- a/src/model.ts
+++ b/src/model.ts
@@ -6,7 +6,7 @@ export type FormHooks = 'change' | 'blur' | 'submit';
 export type ValidatorFn<T> = NgValidatorFN | TypedValidatorFn<T>
 export type AsyncValidatorFn<T> = NgAsyncValidatorFn | TypedAsyncValidatorFn<T>
 
-export type Controls<T> = { [P in keyof T]: AbstractControl<T[P]> };
+export type Controls<T = unknown> = { [P in keyof T]: AbstractControl<T[P]> };
 export type FormState<T> = T | { value: T, disabled: boolean };
 export type StateAndValidators<T> = [FormState<T>] |
   [FormState<T>, ValidatorFn<T> | ValidatorFn<T>[]] |
@@ -39,6 +39,17 @@ export interface AsyncValidator<T> extends Validator<T> {
   validate(c: AbstractControl<T>): Promise<ValidationErrors | null> | Observable<ValidationErrors | null>;
 }
 
+// helpers to support typing 'get'
+type HasControls = FormArray | FormGroup;
+type GetControls<T extends HasControls> = T['controls'];
+type GetControlKeys<T extends HasControls> = keyof GetControls<T>;
+type GetControl<T extends HasControls, K extends GetControlKeys<T>> = GetControls<T>[K];
+
+/**
+ * Get the type of the data stored by a control.
+ */
+export type Static<T extends AbstractControl<any>> = T['value'];
+
 /**
  * This is the base class for `FormControl`, `FormGroup`, and `FormArray`.
  *
@@ -52,7 +63,8 @@ export interface AsyncValidator<T> extends Validator<T> {
  * @see [Dynamic Forms Guide](/guide/dynamic-form)
  *
  */
-export abstract class AbstractControl<T> {
+// <T> is the type of the value stored by the control, <C> is the type of the inner controls, if any
+export abstract class AbstractControl<T = unknown, C = unknown> {
 
   /**
    * The parent control.
@@ -376,7 +388,7 @@ export abstract class AbstractControl<T> {
   /**
    * Patches the value of the control. Abstract method (implemented in sub-classes).
    */
-  abstract patchValue(value: Partial<T>, options?: Object): void;
+  abstract patchValue(value: T, options?: Object): void;
 
   /**
    * Resets the control. Abstract method (implemented in sub-classes).
@@ -446,12 +458,16 @@ export abstract class AbstractControl<T> {
    *
    * * `this.form.get(['person', 'name']);`
    */
-  abstract get<K extends keyof T>(path: K): AbstractControl<T[K]> | null;
-  abstract get<K1 extends keyof T>(path: [K1]): AbstractControl<T[K1]> | null;
-  abstract get<K1 extends keyof T, K2 extends keyof T[K1]>(path: [K1, K2]): AbstractControl<T[K1][K2]> | null;
-  abstract get<K1 extends keyof T, K2 extends keyof T[K1], K3 extends keyof T[K1][K2]>(path: [K1, K2, K3]): AbstractControl<T[K1][K2][K3]> | null;
-  abstract get<K1 extends keyof T, K2 extends keyof T[K1], K3 extends keyof T[K1][K2], K4 extends keyof T[K1][K2][K3]>(path: [K1, K2, K3, K4]): AbstractControl<T[K1][K2][K3][K4]> | null;
-  abstract get<K1 extends keyof T, K2 extends keyof T[K1], K3 extends keyof T[K1][K2], K4 extends keyof T[K1][K2][K3], K5 extends keyof T[K1][K2][K3][K4]>(path: [K1, K2, K3, K4, K5]): AbstractControl<T[K1][K2][K3][K4][K5]> | null;
+  get<K1 extends keyof C>(path: [K1]): C[K1];
+  get<K1 extends keyof C, C2 extends C[K1] & HasControls, K2 extends GetControlKeys<C2>>(path: [K1, K2]): GetControl<C2, K2>;
+  get<K1 extends keyof C, C2 extends C[K1] & HasControls, K2 extends GetControlKeys<C2>, C3 extends GetControl<C2, K2> & HasControls, K3 extends GetControlKeys<C3>>(path: [K1, K2, K3]): GetControl<C3, K3>;
+  get<K1 extends keyof C, C2 extends C[K1] & HasControls, K2 extends GetControlKeys<C2>, C3 extends GetControl<C2, K2> & HasControls, K3 extends GetControlKeys<C3>, C4 extends GetControl<C3, K3> & HasControls, K4 extends GetControlKeys<C4>>(path: [K1, K2, K3, K4]): GetControl<C4, K4>;
+  get<K1 extends keyof C, C2 extends C[K1] & HasControls, K2 extends GetControlKeys<C2>, C3 extends GetControl<C2, K2> & HasControls, K3 extends GetControlKeys<C3>, C4 extends GetControl<C3, K3> & HasControls, K4 extends GetControlKeys<C4>, C5 extends GetControl<C4, K4> & HasControls, K5 extends GetControlKeys<C5>>(path: [K1, K2, K3, K4, K5]): GetControl<C5, K5>;
+
+  get<K1 extends keyof C>(path: K1): C[K1];
+
+  get(path: any): any {
+  }
 
   /**
    * @description
@@ -583,7 +599,8 @@ export abstract class AbstractControl<T> {
  *
  *
  */
-export class FormArray<T> extends AbstractControl<T[]> {
+export class FormArray<T extends AbstractControl<any> = AbstractControl> extends AbstractControl<Array<Static<T>>, Array<T>> {
+  controls: Array<T>;
 
   /**
    * Creates a new `FormArray` instance.
@@ -598,13 +615,11 @@ export class FormArray<T> extends AbstractControl<T[]> {
    * @param asyncValidator A single async validator or array of async validator functions
    *
    */
-  constructor(controls: AbstractControl<T>[],
-    validatorOrOpts?: ValidatorFn<T> | ValidatorFn<T>[] | AbstractControlOptions<T> | null,
-    asyncValidator?: AsyncValidatorFn<T> | AsyncValidatorFn<T>[] | null) {
+  constructor(controls: Array<T>,
+    validatorOrOpts?: ValidatorFn<Static<T>> | ValidatorFn<Static<T>>[] | AbstractControlOptions<Static<T>> | null,
+    asyncValidator?: AsyncValidatorFn<Static<T>> | AsyncValidatorFn<Static<T>>[] | null) {
     super()
   };
-
-  controls: AbstractControl<T>[];
 
   /**
    * Length of the control array.
@@ -616,24 +631,16 @@ export class FormArray<T> extends AbstractControl<T[]> {
    *
    * @param index Index in the array to retrieve the control
    */
-  at(index: number): AbstractControl<T> {
+  at(index: number): T {
     return this.controls[index]
   };
-
-  get(path: [number]): AbstractControl<T> | null;
-  get<K1 extends keyof T>(path: [number, K1]): AbstractControl<T[K1]> | null;
-  get<K1 extends keyof T, K2 extends keyof T[K1]>(path: [number, K1, K2]): AbstractControl<T[K1][K2]> | null;
-  get<K1 extends keyof T, K2 extends keyof T[K1], K3 extends keyof T[K1][K2]>(path: [number, K1, K2, K3]): AbstractControl<T[K1][K2][K3]> | null;
-  get<K1 extends keyof T, K2 extends keyof T[K1], K3 extends keyof T[K1][K2], K4 extends keyof T[K1][K2][K3]>(path: [number, K1, K2, K3, K4]): AbstractControl<T[K1][K2][K3][K4]> | null;
-  get(path: any): any {
-  }
 
   /**
    * Insert a new `AbstractControl` at the end of the array.
    *
    * @param control Form control to be inserted
    */
-  push(control: AbstractControl<T>): void {
+  push(control: T): void {
   };
 
   /**
@@ -642,7 +649,7 @@ export class FormArray<T> extends AbstractControl<T[]> {
    * @param index Index in the array to insert the control
    * @param control Form control to be inserted
    */
-  insert(index: number, control: AbstractControl<T>): void {
+  insert(index: number, control: T): void {
   };
 
   /**
@@ -659,7 +666,7 @@ export class FormArray<T> extends AbstractControl<T[]> {
    * @param index Index in the array to replace the control
    * @param control The `AbstractControl` control to replace the existing control
    */
-  setControl(index: number, control: AbstractControl<T>): void {
+  setControl(index: number, control: T): void {
   };
 
   /**
@@ -696,7 +703,7 @@ export class FormArray<T> extends AbstractControl<T[]> {
    * The configuration options are passed to the {@link AbstractControl#updateValueAndValidity
    * updateValueAndValidity} method.
    */
-  setValue(value: T[], options?: {
+  setValue(value: Static<this>, options?: {
     onlySelf?: boolean;
     emitEvent?: boolean;
   }): void {
@@ -735,7 +742,7 @@ export class FormArray<T> extends AbstractControl<T[]> {
    * The configuration options are passed to the {@link AbstractControl#updateValueAndValidity
    * updateValueAndValidity} method.
    */
-  patchValue(value: T[], options?: {
+  patchValue(value: Static<this>, options?: {
     onlySelf?: boolean;
     emitEvent?: boolean;
   }): void {
@@ -786,7 +793,7 @@ export class FormArray<T> extends AbstractControl<T[]> {
    * The configuration options are passed to the {@link AbstractControl#updateValueAndValidity
    * updateValueAndValidity} method.
    */
-  reset(value?: T[], options?: {
+  reset(value?: Static<this>, options?: {
     onlySelf?: boolean;
     emitEvent?: boolean;
   }): void {
@@ -798,7 +805,7 @@ export class FormArray<T> extends AbstractControl<T[]> {
    * Reports all values regardless of disabled status.
    * For enabled controls only, the `value` property is the best way to get the value of the array.
    */
-  getRawValue(): T[] {
+  getRawValue(): Static<this> {
     throw undefined
   };
 
@@ -907,8 +914,9 @@ export class FormArray<T> extends AbstractControl<T[]> {
  * }, { updateOn: 'blur' });
  * ```
  */
-export class FormGroup<T> extends AbstractControl<T> {
-  controls: Controls<T>;
+type ControlsStaticType<T extends { [_: string]: AbstractControl }> = { [K in keyof T]: Static<T[K]> };
+export class FormGroup<T extends Controls<any> = Controls> extends AbstractControl<ControlsStaticType<T>, T> {
+  controls: T;
 
   /**
    * Creates a new `FormGroup` instance.
@@ -923,9 +931,9 @@ export class FormGroup<T> extends AbstractControl<T> {
    * @param asyncValidator A single async validator or array of async validator functions
    *
    */
-  constructor(controls: Controls<T>,
-    validatorOrOpts?: ValidatorFn<T> | ValidatorFn<T>[] | AbstractControlOptions<T> | null,
-    asyncValidator?: AsyncValidatorFn<T> | AsyncValidatorFn<T>[] | null) {
+  constructor(controls: T,
+    validatorOrOpts?: ValidatorFn<ControlsStaticType<T>> | ValidatorFn<ControlsStaticType<T>>[] | AbstractControlOptions<ControlsStaticType<T>> | null,
+    asyncValidator?: AsyncValidatorFn<ControlsStaticType<T>> | AsyncValidatorFn<ControlsStaticType<T>>[] | null) {
     super()
   };
 
@@ -967,7 +975,7 @@ export class FormGroup<T> extends AbstractControl<T> {
    * @param name The control name to replace in the collection
    * @param control Provides the control for the given name
    */
-  setControl<K extends keyof T>(name: K, control: AbstractControl<T[K]>): void {
+  setControl<K extends keyof T>(name: K, control: T[K]): void {
   };
 
   /**
@@ -1018,7 +1026,7 @@ export class FormGroup<T> extends AbstractControl<T> {
    * observables emit events with the latest status and value when the control value is updated.
    * When false, no events are emitted.
    */
-  setValue(value: T, options?: {
+  setValue(value: Static<this>, options?: {
     onlySelf?: boolean;
     emitEvent?: boolean;
   }): void {
@@ -1057,7 +1065,7 @@ export class FormGroup<T> extends AbstractControl<T> {
    * The configuration options are passed to the {@link AbstractControl#updateValueAndValidity
    * updateValueAndValidity} method.
    */
-  patchValue(value: Partial<T>, options?: {
+  patchValue(value: Partial<Static<this>>, options?: {
     onlySelf?: boolean;
     emitEvent?: boolean;
   }): void {
@@ -1120,7 +1128,7 @@ export class FormGroup<T> extends AbstractControl<T> {
    * console.log(this.form.get('first').status);  // 'DISABLED'
    * ```
    */
-  reset(value?: Partial<T>, options?: {
+  reset(value?: Partial<Static<this>>, options?: {
     onlySelf?: boolean;
     emitEvent?: boolean;
   }): void {
@@ -1133,18 +1141,9 @@ export class FormGroup<T> extends AbstractControl<T> {
    * The `value` property is the best way to get the value of the group, because
    * it excludes disabled controls in the `FormGroup`.
    */
-  getRawValue(): T {
+  getRawValue(): Static<this> {
     throw undefined
   };
-
-  get<K1 extends keyof T>(path: [K1]): AbstractControl<T[K1]>;
-  get<K1 extends keyof T, K2 extends keyof T[K1]>(path: [K1, K2]): AbstractControl<T[K1][K2]> | null;
-  get<K1 extends keyof T, K2 extends keyof T[K1], K3 extends keyof T[K1][K2]>(path: [K1, K2, K3]): AbstractControl<T[K1][K2][K3]> | null;
-  get<K1 extends keyof T, K2 extends keyof T[K1], K3 extends keyof T[K1][K2], K4 extends keyof T[K1][K2][K3]>(path: [K1, K2, K3, K4]): AbstractControl<T[K1][K2][K3][K4]> | null;
-  get<K1 extends keyof T, K2 extends keyof T[K1], K3 extends keyof T[K1][K2], K4 extends keyof T[K1][K2][K3], K5 extends keyof T[K1][K2][K3][K4]>(path: [K1, K2, K3, K4, K5]): AbstractControl<T[K1][K2][K3][K4][K5]> | null;
-  get<K extends keyof T>(path: K): AbstractControl<T[K]>;
-  get(path: any): any {
-  }
 }
 
 
@@ -1243,8 +1242,8 @@ export class FormGroup<T> extends AbstractControl<T> {
  * console.log(control.status); // 'DISABLED'
  *
  */
-export class FormControl<T> extends AbstractControl<T> {
-
+export class FormControl<T> extends AbstractControl<T, void> {
+  
   /**
    * Creates a new `FormControl` instance.
    *
@@ -1397,7 +1396,9 @@ export class FormBuilder {
    * * `asyncValidator`: A single async validator or array of async validator functions
    *
    */
-  group<T>(controlsConfig: ControlsConfig<T>, options?: FormBuilderFormGroupOptions<T> | AbstractControlOptions<T>): FormGroup<T> {
+  group<T extends Controls<any>>(controlsConfig: T, options?: FormBuilderFormGroupOptions<ControlsStaticType<T>> | AbstractControlOptions<ControlsStaticType<T>>): FormGroup<T>;
+  group<T>(controlsConfig: ControlsConfig<T>, options?: FormBuilderFormGroupOptions<T> | AbstractControlOptions<T>): FormGroup<Controls<T>>;
+  group(controlsConfig: any, options?: any): any {
     throw undefined
   };
 
@@ -1445,9 +1446,13 @@ export class FormBuilder {
    * @param asyncValidator A single async validator or array of async validator
    * functions.
    */
+  array<T extends AbstractControl<any>>(controlsConfig: Array<T>,
+    validatorOrOpts?: ValidatorFn<Static<T>> | ValidatorFn<Static<T>>[] | null,
+    asyncValidator?: AsyncValidatorFn<Static<T>> | AsyncValidatorFn<Static<T>>[] | null): FormArray<T>;
   array<T>(controlsConfig: ControlConfig<T>[],
     validatorOrOpts?: ValidatorFn<T> | ValidatorFn<T>[] | null,
-    asyncValidator?: AsyncValidatorFn<T> | AsyncValidatorFn<T>[] | null): FormArray<T> {
+    asyncValidator?: AsyncValidatorFn<T> | AsyncValidatorFn<T>[] | null): FormArray<AbstractControl<T>>;
+  array(controlsConfig: any): any {
     throw undefined
   };
 }

--- a/test/compile-test-form-array.ts
+++ b/test/compile-test-form-array.ts
@@ -1,5 +1,5 @@
 import {AbstractControl, FormArray, FormControl} from '../src/model';
 import {Bar} from './interfaces';
 
-let barArray: FormArray<Bar> = new FormArray([new FormControl<Bar>({prop: ""}), new FormControl<Bar>(undefined)]);
+let barArray: FormArray<FormControl<Bar>> = new FormArray([new FormControl<Bar>({prop: ""}), new FormControl<Bar>(undefined)]);
 let barsControll: AbstractControl<Bar[]> = barArray;

--- a/test/compile-test-form-builder.ts
+++ b/test/compile-test-form-builder.ts
@@ -1,6 +1,6 @@
 import {Validators} from '@angular/forms'
-import {AbstractControl, FormArray, FormBuilder, FormControl, FormGroup} from '../src/model';
-import {Address, Bar, Foo, Hero} from './interfaces';
+import { AbstractControl, FormArray, FormBuilder, FormControl, FormGroup, Controls} from '../src/model';
+import {Address, Bar, Hero} from './interfaces';
 
 const fb = new FormBuilder();
 // FormControl
@@ -9,29 +9,31 @@ let stringFormControl: FormControl<string>;
 
 stringFormControl = fb.control('');
 stringFormControl = fb.control({value: '', disabled: true});
-// FormArray
-let stringFormArray: FormArray<string>;
 
-stringFormArray = fb.array<string>(['2345', 'ieiae', fb.control<string>('uieie')]);
-stringFormArray = fb.array<string>([fb.control<string>('uieie')]);
+// FormArray
+let stringFormArray: FormArray<FormControl<string>>;
+
+const stringFormArrayGeneric: FormArray<AbstractControl<string>> = fb.array<string>(['2345', 'ieiae', fb.control<string>('uieie')]);
+stringFormArray = fb.array([fb.control<string>('uieie')]);
 stringFormArray.setValue(['foo', 'bar']);
-let barFormArray: FormArray<Bar>;
+
+let barFormArray: FormArray<AbstractControl<Bar>>;
 barFormArray = fb.array([fb.control({prop: ''})]);
 barFormArray = fb.array<Bar>([[{prop: ''}, Validators.required]]);
 barFormArray = fb.array<Bar>([[{prop: ''}, [Validators.required]]]);
 barFormArray = fb.array<Bar>([[{prop: ''}, [Validators.required, Validators.minLength(5)]]]);
 
 // FormGroup
-const heroFormGroup: FormGroup<Hero> = fb.group<Hero>({
+const heroFormGroup = fb.group<Hero>({
   name: '',
   secretLairs: fb.array<Address>([new Address(), {name: 'foo'}]),
   power: '',
   sidekick: ''
 });
-const namecontrol: AbstractControl<string> | null = heroFormGroup.get('name');
-const lairs: AbstractControl<Address[]> | null = heroFormGroup.get('secretLairs');
+const namecontrol: AbstractControl<string> = heroFormGroup.get('name');
+const lairs: AbstractControl<Address[]> = heroFormGroup.get('secretLairs');
 
-let barFormGroup: FormGroup<Bar>;
+let barFormGroup: FormGroup<Controls<Bar>>;
 barFormGroup= fb.group<Bar>({prop: ''});
 barFormGroup = fb.group<Bar>({prop: {value: '', disabled: true}});
 barFormGroup = fb.group<Bar>({prop: ['', Validators.required]});

--- a/test/compile-test-form-group.ts
+++ b/test/compile-test-form-group.ts
@@ -1,27 +1,48 @@
-import {AbstractControl, FormArray, FormControl, FormGroup} from '../src/model';
-import {Address, Bar, Foo, Hero} from './interfaces';
+import { FormArray, FormControl, FormGroup, Static } from '../src/model';
+import { Bar } from './interfaces';
 
-let fooFormGroup: FormGroup<Foo> = new FormGroup<Foo>({
+let fooFormGroup = new FormGroup({
   field: new FormControl<Bar>(undefined),
-  array: new FormArray<Bar>([])
+  group: new FormGroup({
+    prop: new FormControl('')
+  }),
+  array: new FormArray(new Array<FormControl<Bar>>())
 });
-fooFormGroup = new FormGroup<Foo>({
+fooFormGroup = new FormGroup({
   field: new FormControl<Bar>(undefined),
+  group: new FormGroup({
+    prop: new FormControl('')
+  }),
   array: new FormArray([new FormControl<Bar>({prop: ""}), new FormControl<Bar>(undefined)])
 });
-let barControl: AbstractControl<Bar> = fooFormGroup.get(['field']);
+let barControl: FormControl<Bar> = fooFormGroup.get(['field']);
 barControl = fooFormGroup.get('field');
-// should be null as 'prop' is only a field in the 'field' FormControl and FormControl.get always returns null
-let stringControl: AbstractControl<string> | null = fooFormGroup.get(['field', 'prop']);
-// should be null as 'prop' is only a field in the 'field' FormControl and FormControl.get always returns null
-let s: string = fooFormGroup.get(['field', 'prop'])!.value;
-// should be null as 'prop' is only a field in the 'field' FormControl and FormControl.get always returns null
-stringControl = fooFormGroup.get('field')!.get('prop');
-const barArray: AbstractControl<Bar[]> | null = fooFormGroup.get('array');
+barControl = fooFormGroup.controls.field;
 
-const heroFormGroup: FormGroup<Hero> = {} as FormGroup<Hero>;
-const namecontrol: AbstractControl<string> | null = heroFormGroup.get('name');
-const lairsControl: AbstractControl<Address[]> | null = heroFormGroup.get('secretLairs');
+// This is correctly recognised as an error
+// Unfortunately the error message isn't very helpful: Argument of type 'string[]' is not assignable to parameter of type '"field" | "array"'
+// let stringControl = fooFormGroup.get(['field', 'prop']);
+
+// the group version works as expected
+let stringControl: FormControl<string> = fooFormGroup.get(['group', 'prop']);
+stringControl = fooFormGroup.controls.group.controls.prop;
+
+const nullControl: null = fooFormGroup.get('field')!.get('prop');
+
+let barArray: FormArray<FormControl<Bar>> = fooFormGroup.get('array');
+barArray = fooFormGroup.controls.array;
+
+// Typescript array dereference is never null so the "get" must also not return null to be consistent, even if sometimes incorrect.
+barControl = fooFormGroup.get(['array', 0]);
+barControl = fooFormGroup.controls.array.controls[0];
 
 // partial Reset
 fooFormGroup.reset({field: new Bar()});
+type Foo = Static<typeof fooFormGroup>;
+const foo: Foo = {
+  field: new Bar(),
+  group: {
+    prop: ''
+  },
+  array: [new Bar()]
+}

--- a/test/tsconfig-test.json
+++ b/test/tsconfig-test.json
@@ -24,7 +24,7 @@
     // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,              /* Enable strict null checks. */
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
-    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    "strictPropertyInitialization": false,    /* Enable strict checking of property initialization in classes. */
     // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
     // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
 


### PR DESCRIPTION
This is a large change, partly inspired by the type structure of https://github.com/pelotom/runtypes

While the generics for the different control types have changed, the form builder supports the existing generic types and so can be used without change.